### PR TITLE
ayamir main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,13 @@ body:
     attributes:
       value: |
         _Before reporting:_ Search [existing issues](https://github.com/ayamir/nvimdots/issues) and check the [FAQ](https://github.com/ayamir/nvimdots/wiki/Issues). Thank you for helping us improve!
+  - type: checkboxes
+    id: is-latest-commit
+    attributes:
+      label: "Version confirmation"
+      description: "The local configuration is up-to-date in the current branch and this issue _persists_."
+      options:
+        - label: "Confirm"
 
   - type: input
     id: nvim-version

--- a/.github/ISSUE_TEMPLATE/lsp_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_issue_report.yml
@@ -6,6 +6,13 @@ body:
     attributes:
       value: |
         _Before reporting:_ Search [existing issues](https://github.com/ayamir/nvimdots/issues) and check the [FAQ](https://github.com/ayamir/nvimdots/wiki/Issues). Thank you for helping us improve!
+  - type: checkboxes
+    id: is-latest-commit
+    attributes:
+      label: "Version confirmation"
+      description: "The local configuration is up-to-date in the current branch and this issue _persists_."
+      options:
+        - label: "Confirm"
 
   - type: input
     id: nvim-version

--- a/lua/core/event.lua
+++ b/lua/core/event.lua
@@ -13,6 +13,22 @@ function autocmd.nvim_create_augroups(definitions)
 	end
 end
 
+-- auto close NvimTree
+vim.api.nvim_create_autocmd("BufEnter", {
+	group = vim.api.nvim_create_augroup("NvimTreeClose", { clear = true }),
+	pattern = "NvimTree_*",
+	callback = function()
+		local layout = vim.api.nvim_call_function("winlayout", {})
+		if
+			layout[1] == "leaf"
+			and vim.api.nvim_buf_get_option(vim.api.nvim_win_get_buf(layout[2]), "filetype") == "NvimTree"
+			and layout[3] == nil
+		then
+			vim.cmd("confirm quit")
+		end
+	end,
+})
+
 function autocmd.load_autocmds()
 	local definitions = {
 		packer = {},
@@ -34,17 +50,12 @@ function autocmd.load_autocmds()
 			{ "BufWritePre", "*.tmp", "setlocal noundofile" },
 			{ "BufWritePre", "*.bak", "setlocal noundofile" },
 			-- auto change directory
-			{ "BufEnter", "*", "silent! lcd %:p:h" },
+			-- { "BufEnter", "*", "silent! lcd %:p:h" },
 			-- auto place to last edit
 			{
 				"BufReadPost",
 				"*",
 				[[if line("'\"") > 1 && line("'\"") <= line("$") | execute "normal! g'\"" | endif]],
-			},
-			{
-				"BufEnter",
-				"*",
-				[[if winnr('$') == 1 && bufname() == 'NvimTree_' . tabpagenr() | quit | endif]],
 			},
 			-- Auto toggle fcitx5
 			-- {"InsertLeave", "* :silent", "!fcitx5-remote -c"},

--- a/lua/core/mapping.lua
+++ b/lua/core/mapping.lua
@@ -8,7 +8,8 @@ local def_map = {
 	-- Vim map
 	["n|<S-Tab>"] = map_cr("normal za"):with_noremap():with_silent(),
 	["n|<C-x>k"] = map_cr("bdelete"):with_noremap():with_silent(),
-	["n|<C-s>"] = map_cu("write"):with_noremap(),
+	["n|<C-s>"] = map_cu("write"):with_noremap():with_silent(),
+	["n|<C-S-s>"] = map_cmd("execute 'silent! write !sudo tee % >/dev/null' <bar> edit!"):with_silent():with_noremap(),
 	["n|Y"] = map_cmd("y$"),
 	["n|D"] = map_cmd("d$"),
 	["n|n"] = map_cmd("nzzzv"):with_noremap(),
@@ -23,7 +24,6 @@ local def_map = {
 	["n|<A-;>"] = map_cr("resize -2"):with_silent(),
 	["n|<A-'>"] = map_cr("resize +2"):with_silent(),
 	["n|<C-q>"] = map_cmd(":wq<CR>"),
-	["n|<A-q>"] = map_cmd(":Bwipeout<CR>"),
 	["n|<A-S-q>"] = map_cmd(":q!<CR>"),
 	["n|<leader>o"] = map_cr("setlocal spell! spelllang=en_us"),
 	-- Insert
@@ -40,7 +40,6 @@ local def_map = {
 	["c|<C-d>"] = map_cmd("<Del>"):with_noremap(),
 	["c|<C-h>"] = map_cmd("<BS>"):with_noremap(),
 	["c|<C-t>"] = map_cmd([[<C-R>=expand("%:p:h") . "/" <CR>]]):with_noremap(),
-	["c|w!!"] = map_cmd("execute 'silent! write !sudo tee % >/dev/null' <bar> edit!"),
 	-- Visual
 	["v|J"] = map_cmd(":m '>+1<cr>gv=gv"),
 	["v|K"] = map_cmd(":m '<-2<cr>gv=gv"),

--- a/lua/core/pack.lua
+++ b/lua/core/pack.lua
@@ -27,6 +27,8 @@ function Packer:load_plugins()
 			end
 		end
 		for _, f in ipairs(tmp) do
+			-- fill list with `plugins.lua`'s path used for later `require` like this:
+			-- list[#list + 1] = "modules/completion/plugins.lua"
 			list[#list + 1] = f:sub(#modules_dir - 6, -1)
 		end
 		return list
@@ -34,6 +36,8 @@ function Packer:load_plugins()
 
 	local plugins_file = get_plugins_list()
 	for _, m in ipairs(plugins_file) do
+		-- require repos which returned in `plugins.lua` like this:
+		-- local repos = require("modules/completion/plugins")
 		local repos = require(m:sub(0, #m - 4))
 		for repo, conf in pairs(repos) do
 			self.repos[#self.repos + 1] = vim.tbl_extend("force", { repo }, conf)

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -1,7 +1,8 @@
 local settings = {}
 local home = os.getenv("HOME")
 
-settings["use_ssh"] = false
+settings["use_ssh"] = true
+settings["format_on_save"] = true
 settings["format_disabled_dirs"] = {
 	home .. "/format_disabled_dir_under_home",
 }

--- a/lua/keymap/init.lua
+++ b/lua/keymap/init.lua
@@ -5,6 +5,8 @@ local map_cmd = bind.map_cmd
 require("keymap.config")
 
 local plug_map = {
+	-- nvim-bufdel
+	["n|<A-q>"] = map_cr("BufDel"):with_noremap():with_silent(),
 	-- Bufferline
 	["n|gb"] = map_cr("BufferLinePick"):with_noremap():with_silent(),
 	["n|<A-j>"] = map_cr("BufferLineCycleNext"):with_noremap():with_silent(),
@@ -30,10 +32,10 @@ local plug_map = {
 	-- Lsp mapp work when insertenter and lsp start
 	["n|<leader>li"] = map_cr("LspInfo"):with_noremap():with_silent():with_nowait(),
 	["n|<leader>lr"] = map_cr("LspRestart"):with_noremap():with_silent():with_nowait(),
-	["n|<A-t>"] = map_cr("LSoutlineToggle"):with_noremap():with_silent(),
+	["n|go"] = map_cr("Lspsaga outline"):with_noremap():with_silent(),
 	["n|g["] = map_cr("Lspsaga diagnostic_jump_prev"):with_noremap():with_silent(),
 	["n|g]"] = map_cr("Lspsaga diagnostic_jump_next"):with_noremap():with_silent(),
-	["n|gs"] = map_cr("Lspsaga signature_help"):with_noremap():with_silent(),
+	["n|gs"] = map_cr("lua vim.lsp.buf.signature_help()"):with_noremap():with_silent(),
 	["n|gr"] = map_cr("Lspsaga rename"):with_noremap():with_silent(),
 	["n|K"] = map_cr("Lspsaga hover_doc"):with_noremap():with_silent(),
 	["n|ga"] = map_cr("Lspsaga code_action"):with_noremap():with_silent(),
@@ -69,20 +71,22 @@ local plug_map = {
 	["n|<leader>tl"] = map_cr("TroubleToggle loclist"):with_noremap():with_silent(),
 	-- Plugin nvim-tree
 	["n|<C-n>"] = map_cr("NvimTreeToggle"):with_noremap():with_silent(),
-	["n|<Leader>nf"] = map_cr("NvimTreeFindFile"):with_noremap():with_silent(),
-	["n|<Leader>nr"] = map_cr("NvimTreeRefresh"):with_noremap():with_silent(),
-	-- Plugin Undotree
-	["n|<Leader>u"] = map_cr("UndotreeToggle"):with_noremap():with_silent(),
+	["n|<leader>nf"] = map_cr("NvimTreeFindFile"):with_noremap():with_silent(),
+	["n|<leader>nr"] = map_cr("NvimTreeRefresh"):with_noremap():with_silent(),
 	-- Plugin Telescope
-	["n|<Leader>fp"] = map_cu("lua require('telescope').extensions.project.project{}"):with_noremap():with_silent(),
-	["n|<Leader>fr"] = map_cu("lua require('telescope').extensions.frecency.frecency{}"):with_noremap():with_silent(),
-	["n|<Leader>fe"] = map_cu("Telescope oldfiles"):with_noremap():with_silent(),
-	["n|<Leader>ff"] = map_cu("Telescope find_files"):with_noremap():with_silent(),
-	["n|<Leader>fc"] = map_cu("Telescope colorscheme"):with_noremap():with_silent(),
-	["n|<Leader>fn"] = map_cu(":enew"):with_noremap():with_silent(),
-	["n|<Leader>fw"] = map_cu("Telescope live_grep"):with_noremap():with_silent(),
-	["n|<Leader>fg"] = map_cu("Telescope git_files"):with_noremap():with_silent(),
-	["n|<Leader>fz"] = map_cu("Telescope zoxide list"):with_noremap():with_silent(),
+	["n|<leader>u"] = map_cr("lua require('telescope').extensions.undo.undo()"):with_noremap():with_silent(),
+	["n|<leader>fp"] = map_cu("lua require('telescope').extensions.projects.projects{}"):with_noremap():with_silent(),
+	["n|<leader>fr"] = map_cu("lua require('telescope').extensions.frecency.frecency{}"):with_noremap():with_silent(),
+	["n|<leader>fw"] = map_cu("lua require('telescope').extensions.live_grep_args.live_grep_args{}")
+		:with_noremap()
+		:with_silent(),
+	["n|<leader>fe"] = map_cu("Telescope oldfiles"):with_noremap():with_silent(),
+	["n|<leader>ff"] = map_cu("Telescope find_files"):with_noremap():with_silent(),
+	["n|<leader>fc"] = map_cu("Telescope colorscheme"):with_noremap():with_silent(),
+	["n|<leader>fn"] = map_cu(":enew"):with_noremap():with_silent(),
+	["n|<leader>fg"] = map_cu("Telescope git_files"):with_noremap():with_silent(),
+	["n|<leader>fz"] = map_cu("Telescope zoxide list"):with_noremap():with_silent(),
+	["n|<leader>fb"] = map_cu("Telescope buffers"):with_noremap():with_silent(),
 	-- Plugin accelerate-jk
 	["n|j"] = map_cmd("v:lua.enhance_jk_move('j')"):with_silent():with_expr(),
 	["n|k"] = map_cmd("v:lua.enhance_jk_move('k')"):with_silent():with_expr(),
@@ -106,6 +110,7 @@ local plug_map = {
 	["n|<leader>sd"] = map_cu("DeleteSession"):with_noremap():with_silent(),
 	-- Plugin SnipRun
 	["v|<leader>r"] = map_cr("SnipRun"):with_noremap():with_silent(),
+	["n|<leader>r"] = map_cu([[%SnipRun]]):with_noremap():with_silent(),
 	-- Plugin dap
 	["n|<F6>"] = map_cr("lua require('dap').continue()"):with_noremap():with_silent(),
 	["n|<leader>dr"] = map_cr("lua require('dap').continue()"):with_noremap():with_silent(),
@@ -125,7 +130,6 @@ local plug_map = {
 	["n|<leader>do"] = map_cr("lua require('dap').step_out()"):with_noremap():with_silent(),
 	["n|<leader>dl"] = map_cr("lua require('dap').repl.open()"):with_noremap():with_silent(),
 	["o|m"] = map_cu([[lua require('tsht').nodes()]]):with_silent(),
-	["c|Q"] = map_cu([[%SnipRun]]):with_silent(),
 	-- Plugin Tabout
 	["i|<A-l>"] = map_cmd([[<Plug>(TaboutMulti)]]):with_silent(),
 	["i|<A-h>"] = map_cmd([[<Plug>(TaboutBackMulti)]]):with_silent(),

--- a/lua/modules/completion/config.lua
+++ b/lua/modules/completion/config.lua
@@ -89,18 +89,21 @@ function config.lspsaga()
 			Parameter = { icons.kind.Parameter, colors.blue },
 			StaticMethod = { icons.kind.StaticMethod, colors.peach },
 		},
+		code_action_lightbulb = {
+			enable = false,
+			enable_in_insert = true,
+			cache_code_action = true,
+			sign = true,
+			update_time = 150,
+			sign_priority = 20,
+			virtual_text = true,
+		},
 		symbol_in_winbar = {
+			in_custom = true,
 			enable = true,
-			in_custom = false,
 			separator = " " .. icons.ui.Separator,
 			show_file = false,
-			-- define how to customize filename, eg: %:., %
-			-- if not set, use default value `%:t`
-			-- more information see `vim.fn.expand` or `expand`
-			-- ## only valid after set `show_file = true`
-			file_formatter = "",
 			click_support = function(node, clicks, button, modifiers)
-				-- To see all avaiable details: vim.pretty_print(node)
 				local st = node.range.start
 				local en = node.range["end"]
 				if button == "l" then
@@ -111,8 +114,8 @@ function config.lspsaga()
 					end
 				elseif button == "r" then
 					if modifiers == "s" then
-						print("lspsaga") -- shift right click to print "lspsaga"
-					end -- jump to node's ending line+char
+						print("symbol_winbar")
+					end
 					vim.fn.cursor(en.line + 1, en.character + 1)
 				elseif button == "m" then
 					-- middle click to visual select node
@@ -340,6 +343,16 @@ function config.mason_install()
 		-- Default: true
 		run_on_start = true,
 	})
+end
+
+function config.copilot()
+	vim.defer_fn(function()
+		require("copilot").setup({
+			filetypes = {
+				["dap-repl"] = false,
+			},
+		})
+	end, 100)
 end
 
 return config

--- a/lua/modules/completion/formatting.lua
+++ b/lua/modules/completion/formatting.lua
@@ -2,8 +2,7 @@ local M = {}
 
 local settings = require("core.settings")
 local disabled_workspaces = settings.format_disabled_dirs
-
-local format_on_save = true
+local format_on_save = settings.format_on_save
 
 vim.api.nvim_create_user_command("FormatToggle", function()
 	M.toggle_format_on_save()
@@ -32,7 +31,7 @@ vim.api.nvim_create_user_command("FormatterToggle", function(opts)
 	end
 end, {
 	nargs = 1,
-	complete = function(_, _, _)
+	complete = function()
 		return {
 			"markdown",
 			"vim",
@@ -74,7 +73,9 @@ end
 
 function M.disable_format_on_save()
 	pcall(vim.api.nvim_del_augroup_by_name, "format_on_save")
-	vim.notify("Disabled format-on-save", vim.log.levels.INFO, { title = "Settings modification success!" })
+	if format_on_save then
+		vim.notify("Disabled format-on-save", vim.log.levels.INFO, { title = "Settings modification success!" })
+	end
 end
 
 function M.configure_format_on_save()
@@ -86,7 +87,7 @@ function M.configure_format_on_save()
 end
 
 function M.toggle_format_on_save()
-	local status, _ = pcall(vim.api.nvim_get_autocmds, {
+	local status = pcall(vim.api.nvim_get_autocmds, {
 		group = "format_on_save",
 		event = "BufWritePre",
 	})

--- a/lua/modules/completion/lsp.lua
+++ b/lua/modules/completion/lsp.lua
@@ -37,7 +37,9 @@ local function custom_attach(client, bufnr)
 		fix_pos = true,
 		hint_enable = true,
 		hi_parameter = "Search",
-		handler_opts = { "double" },
+		handler_opts = {
+			border = "rounded",
+		},
 	})
 end
 
@@ -102,25 +104,24 @@ for _, server in ipairs(mason_lsp.get_installed_servers()) do
 						preloadFileSize = 10000,
 					},
 					telemetry = { enable = false },
+					-- Do not override treesitter lua highlighting with sumneko lua highlighting
+					semantic = { enable = false },
 				},
 			},
 		})
 	elseif server == "clangd" then
-		local copy_capabilities = capabilities
-		copy_capabilities.offsetEncoding = { "utf-16" }
 		nvim_lsp.clangd.setup({
-			capabilities = copy_capabilities,
+			capabilities = vim.tbl_deep_extend("keep", { offsetEncoding = { "utf-16", "utf-8" } }, capabilities),
 			single_file_support = true,
 			on_attach = custom_attach,
 			cmd = {
 				"clangd",
 				"--background-index",
 				"--pch-storage=memory",
-				-- You MUST set this arg ↓ to your clangd executable location (if not included)!
+				-- You MUST set this arg ↓ to your c/cpp compiler location (if not included)!
 				"--query-driver=/usr/bin/clang++,/usr/bin/**/clang-*,/bin/clang,/bin/clang++,/usr/bin/gcc,/usr/bin/g++",
 				"--clang-tidy",
 				"--all-scopes-completion",
-				"--cross-file-rename",
 				"--completion-style=detailed",
 				"--header-insertion-decorators",
 				"--header-insertion=iwyu",

--- a/lua/modules/completion/plugins.lua
+++ b/lua/modules/completion/plugins.lua
@@ -21,7 +21,7 @@ completion["williamboman/mason.nvim"] = {
 }
 completion["glepnir/lspsaga.nvim"] = {
 	opt = true,
-	event = "LspAttach",
+	after = "nvim-lspconfig",
 	config = conf.lspsaga,
 }
 completion["ray-x/lsp_signature.nvim"] = { opt = true, after = "nvim-lspconfig" }
@@ -29,8 +29,8 @@ completion["hrsh7th/nvim-cmp"] = {
 	config = conf.cmp,
 	event = "InsertEnter",
 	requires = {
-		{ "onsails/lspkind.nvim" },
-		{ "lukas-reineke/cmp-under-comparator" },
+		{ "onsails/lspkind.nvim", module = "lspkind" },
+		{ "lukas-reineke/cmp-under-comparator", module = "cmp-under-comparator" },
 		{ "saadparwaiz1/cmp_luasnip", after = "LuaSnip" },
 		{ "hrsh7th/cmp-nvim-lsp", after = "cmp_luasnip" },
 		{ "hrsh7th/cmp-nvim-lua", after = "cmp-nvim-lsp" },
@@ -60,9 +60,17 @@ completion["dcampos/nvim-snippy"] = {
 	opt = true,
 	config = conf.nvim_snippy,
 }
-completion["dcampos/cmp-snippy"] = {
-	after = "nvim-snippy",
-	config = conf.cmp_snippy,
+completion["zbirenbaum/copilot.lua"] = {
+	cmd = "Copilot",
+	event = "VimEnter",
+	config = conf.copilot,
+}
+completion["zbirenbaum/copilot-cmp"] = {
+	after = "copilot.lua",
+	module = "copilot_cmp",
+	config = function()
+		require("copilot_cmp").setup()
+	end,
 }
 -- completion["zbirenbaum/copilot.lua"] = {
 -- 	event = "VimEnter",

--- a/lua/modules/editor/config.lua
+++ b/lua/modules/editor/config.lua
@@ -321,7 +321,7 @@ function config.dap()
 	dap.configurations.c = dap.configurations.cpp
 	dap.configurations.rust = dap.configurations.cpp
 
-	dap.adapters.go = function(callback, config)
+	dap.adapters.go = function(callback)
 		local stdout = vim.loop.new_pipe(false)
 		local handle
 		local pid_or_err

--- a/lua/modules/editor/plugins.lua
+++ b/lua/modules/editor/plugins.lua
@@ -74,7 +74,7 @@ editor["akinsho/toggleterm.nvim"] = {
 }
 editor["NvChad/nvim-colorizer.lua"] = {
 	opt = true,
-	event = "BufReadPost",
+	after = "nvim-treesitter",
 	config = conf.nvim_colorizer,
 }
 editor["rmagatti/auto-session"] = {
@@ -109,9 +109,9 @@ editor["rcarriga/nvim-dap-ui"] = {
 	config = conf.dapui,
 }
 editor["tpope/vim-fugitive"] = { opt = true, cmd = { "Git", "G" } }
-editor["famiu/bufdelete.nvim"] = {
+editor["ojroques/nvim-bufdel"] = {
 	opt = true,
-	cmd = { "Bdelete", "Bwipeout", "Bdelete!", "Bwipeout!" },
+	event = "BufReadPost",
 }
 editor["edluffy/specs.nvim"] = {
 	opt = true,
@@ -121,7 +121,6 @@ editor["edluffy/specs.nvim"] = {
 editor["abecodes/tabout.nvim"] = {
 	opt = true,
 	event = "InsertEnter",
-	wants = "nvim-treesitter",
 	after = "nvim-cmp",
 	config = conf.tabout,
 }

--- a/lua/modules/lang/config.lua
+++ b/lua/modules/lang/config.lua
@@ -21,7 +21,9 @@ function config.rust_tools()
 					fix_pos = true,
 					hint_enable = true,
 					hi_parameter = "Search",
-					handler_opts = { "double" },
+					handler_opts = {
+						border = "rounded",
+					},
 				})
 			end,
 

--- a/lua/modules/lang/plugins.lua
+++ b/lua/modules/lang/plugins.lua
@@ -11,7 +11,7 @@ lang["simrat39/rust-tools.nvim"] = {
 	opt = true,
 	ft = "rust",
 	config = conf.rust_tools,
-	requires = { { "nvim-lua/plenary.nvim", opt = false } },
+	requires = "nvim-lua/plenary.nvim",
 }
 -- lang["kristijanhusak/orgmode.nvim"] = {
 -- 	opt = true,

--- a/lua/modules/tools/config.lua
+++ b/lua/modules/tools/config.lua
@@ -2,10 +2,12 @@ local config = {}
 
 function config.telescope()
 	vim.api.nvim_command([[packadd sqlite.lua]])
+	vim.api.nvim_command([[packadd project.nvim]])
 	vim.api.nvim_command([[packadd telescope-fzf-native.nvim]])
-	vim.api.nvim_command([[packadd telescope-project.nvim]])
 	vim.api.nvim_command([[packadd telescope-frecency.nvim]])
 	vim.api.nvim_command([[packadd telescope-zoxide]])
+	vim.api.nvim_command([[packadd telescope-live-grep-args.nvim]])
+	vim.api.nvim_command([[packadd telescope-undo.nvim]])
 
 	local icons = { ui = require("modules.ui.icons").get("ui", true) }
 	local telescope_actions = require("telescope.actions.set")
@@ -20,6 +22,7 @@ function config.telescope()
 			return true
 		end,
 	}
+	local lga_actions = require("telescope-live-grep-args.actions")
 
 	require("telescope").setup({
 		defaults = {
@@ -55,6 +58,33 @@ function config.telescope()
 				show_unindexed = true,
 				ignore_patterns = { "*.git/*", "*/tmp/*" },
 			},
+			live_grep_args = {
+				auto_quoting = true, -- enable/disable auto-quoting
+				-- define mappings, e.g.
+				mappings = { -- extend mappings
+					i = {
+						["<C-k>"] = lga_actions.quote_prompt(),
+						["<C-i>"] = lga_actions.quote_prompt({ postfix = " --iglob " }),
+					},
+				},
+			},
+			undo = {
+				side_by_side = true,
+				layout_config = {
+					preview_height = 0.8,
+				},
+				mappings = { -- this whole table is the default
+					i = {
+						-- IMPORTANT: Note that telescope-undo must be available when telescope is configured if
+						-- you want to use the following actions. This means installing as a dependency of
+						-- telescope in it's `requirements` and loading this extension from there instead of
+						-- having the separate plugin definition as outlined above. See issue #6.
+						["<cr>"] = require("telescope-undo.actions").yank_additions,
+						["<S-cr>"] = require("telescope-undo.actions").yank_deletions,
+						["<C-cr>"] = require("telescope-undo.actions").restore,
+					},
+				},
+			},
 		},
 		pickers = {
 			buffers = fixfolds,
@@ -68,10 +98,25 @@ function config.telescope()
 
 	require("telescope").load_extension("notify")
 	require("telescope").load_extension("fzf")
-	require("telescope").load_extension("project")
+	require("telescope").load_extension("projects")
 	require("telescope").load_extension("zoxide")
 	require("telescope").load_extension("frecency")
-	-- require("telescope").load_extension("session-lens")
+	require("telescope").load_extension("live_grep_args")
+	require("telescope").load_extension("undo")
+end
+
+function config.project()
+	require("project_nvim").setup({
+		manual_mode = false,
+		detection_methods = { "lsp", "pattern" },
+		patterns = { ".git", "_darcs", ".hg", ".bzr", ".svn", "Makefile", "package.json" },
+		ignore_lsp = { "efm", "copilot" },
+		exclude_dirs = {},
+		show_hidden = false,
+		silent_chdir = true,
+		scope_chdir = "global",
+		datapath = vim.fn.stdpath("data"),
+	})
 end
 
 function config.trouble()
@@ -88,6 +133,8 @@ function config.trouble()
 		mode = "document_diagnostics", -- "workspace_diagnostics", "document_diagnostics", "quickfix", "lsp_references", "loclist"
 		fold_open = icons.ui.ArrowOpen, -- icon used for open folds
 		fold_closed = icons.ui.ArrowClosed, -- icon used for closed folds
+		group = true, -- group results by file
+		padding = true, -- add an extra new line on top of the list
 		action_keys = {
 			-- key mappings for actions in the trouble list
 			-- map to {} to remove a mapping, for example:
@@ -115,6 +162,7 @@ function config.trouble()
 		auto_close = false, -- automatically close the list when you have no diagnostics
 		auto_preview = true, -- automatically preview the location of the diagnostic. <esc> to close preview and go back to last window
 		auto_fold = false, -- automatically fold a file trouble list at creation
+		auto_jump = { "lsp_definitions" }, -- for the given modes, automatically jump if there is only a single result
 		signs = {
 			-- icons / text used for a diagnostic
 			error = icons.diagnostics.Error_alt,
@@ -123,7 +171,7 @@ function config.trouble()
 			information = icons.diagnostics.Information_alt,
 			other = icons.diagnostics.Question_alt,
 		},
-		use_lsp_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
+		use_diagnostic_signs = false, -- enabling this will use the signs defined in your lsp client
 	})
 end
 
@@ -177,8 +225,14 @@ function config.wilder()
 		),
 	})
 
+	local match_hl = require("modules.utils").hl_to_rgb("String", false, "#ABE9B3")
+
 	local popupmenu_renderer = wilder.popupmenu_renderer(wilder.popupmenu_border_theme({
 		border = "rounded",
+		highlights = {
+			border = "Title", -- highlight to use for the border
+			accent = wilder.make_hl("WilderAccent", "Pmenu", { { a = 0 }, { a = 0 }, { foreground = match_hl } }),
+		},
 		empty_message = wilder.popupmenu_empty_message_with_spinner(),
 		highlighter = wilder.lua_fzy_highlighter(),
 		left = {
@@ -254,6 +308,23 @@ function config.legendary()
 			results_view = "float",
 			keep_contents = true,
 		},
+		sort = {
+			-- sort most recently used item to the top
+			most_recent_first = true,
+			-- sort user-defined items before built-in items
+			user_items_first = true,
+			frecency = {
+				-- the directory to store the database in
+				db_root = string.format("%s/legendary/", vim.fn.stdpath("data")),
+				-- the maximum number of timestamps for a single item
+				-- to store in the database
+				max_timestamps = 10,
+			},
+		},
+		-- Directory used for caches
+		cache_path = string.format("%s/legendary/", vim.fn.stdpath("cache")),
+		-- Log level, one of 'trace', 'debug', 'info', 'warn', 'error', 'fatal'
+		log_level = "info",
 	})
 
 	require("which-key").register({
@@ -285,6 +356,7 @@ function config.legendary()
 				f = "find: File under current work directory",
 				g = "find: File under current git directory",
 				n = "edit: New file",
+				b = "find: Buffer opened",
 			},
 			h = {
 				name = "Gitsigns commands",
@@ -320,31 +392,34 @@ function config.legendary()
 			},
 			t = {
 				name = "Trouble commands",
-				d = "lsp: show document diagnostics",
-				w = "lsp: show workspace diagnostics",
-				q = "lsp: show quickfix list",
-				l = "lsp: show loclist",
+				d = "lsp: Show document diagnostics",
+				w = "lsp: Show workspace diagnostics",
+				q = "lsp: Show quickfix list",
+				l = "lsp: Show loclist",
 			},
 		},
 		["g"] = {
-			c = "lsp: Code action",
+			a = "lsp: Code action",
 			d = "lsp: Preview definition",
 			D = "lsp: Goto definition",
 			h = "lsp: Show reference",
+			o = "lsp: Toggle outline",
 			r = "lsp: Rename",
 			s = "lsp: Signature help",
 			t = "lsp: Toggle trouble list",
 			b = "buffer: Buffer pick",
 			p = {
 				name = "git commands",
-				s = "git: push",
-				l = "git: pull",
+				s = "git: Push",
+				l = "git: Pull",
 			},
 		},
 		["<leader>G"] = "git: Show fugitive",
 		["<leader>g"] = "git: Show lazygit",
 		["<leader>D"] = "git: Show diff",
 		["<leader><leader>D"] = "git: Close diff",
+		["]g"] = "git: Goto next hunk",
+		["[g"] = "git: Goto prev hunk",
 		["g["] = "lsp: Goto prev diagnostic",
 		["g]"] = "lsp: Goto next diagnostic",
 		["<leader>w"] = "jump: Goto word",
@@ -353,6 +428,9 @@ function config.legendary()
 		["<leader>c"] = "jump: Goto one char",
 		["<leader>cc"] = "jump: Goto two chars",
 		["<leader>o"] = "edit: Check spell",
+		["<leader>u"] = "edit: Show undo history",
+		["<leader>r"] = "tool: Code snip run",
+		["<F12>"] = "tool: Markdown preview",
 	})
 end
 

--- a/lua/modules/tools/plugins.lua
+++ b/lua/modules/tools/plugins.lua
@@ -1,34 +1,40 @@
 local tools = {}
 local conf = require("modules.tools.config")
 
-tools["nvim-lua/plenary.nvim"] = { opt = false }
+tools["nvim-lua/plenary.nvim"] = { opt = true, module = "plenary" }
 tools["nvim-telescope/telescope.nvim"] = {
 	opt = true,
 	module = "telescope",
 	cmd = "Telescope",
 	config = conf.telescope,
 	requires = {
-		{ "nvim-lua/plenary.nvim", opt = false },
+		"nvim-lua/plenary.nvim",
 		{ "nvim-lua/popup.nvim", opt = true },
+		{ "debugloop/telescope-undo.nvim", opt = true },
 	},
+}
+tools["ahmedkhalf/project.nvim"] = {
+	opt = true,
+	after = "telescope.nvim",
+	config = conf.project,
 }
 tools["nvim-telescope/telescope-fzf-native.nvim"] = {
 	opt = true,
 	run = "make",
-	after = "telescope.nvim",
-}
-tools["nvim-telescope/telescope-project.nvim"] = {
-	opt = true,
-	after = "telescope-fzf-native.nvim",
+	after = "project.nvim",
 }
 tools["nvim-telescope/telescope-frecency.nvim"] = {
 	opt = true,
-	after = "telescope-project.nvim",
+	after = "telescope-fzf-native.nvim",
 	requires = { { "kkharji/sqlite.lua", opt = true } },
 }
 tools["jvgrootveld/telescope-zoxide"] = {
 	opt = true,
 	after = "telescope-frecency.nvim",
+}
+tools["nvim-telescope/telescope-live-grep-args.nvim"] = {
+	opt = true,
+	after = "telescope-zoxide",
 }
 tools["michaelb/sniprun"] = {
 	opt = true,
@@ -62,6 +68,8 @@ tools["mrjones2014/legendary.nvim"] = {
 	config = conf.legendary,
 	requires = {
 		{ "stevearc/dressing.nvim", opt = false, config = conf.dressing },
+		"kkharji/sqlite.lua",
+		"folke/which-key.nvim",
 	},
 }
 

--- a/lua/modules/ui/icons.lua
+++ b/lua/modules/ui/icons.lua
@@ -29,7 +29,7 @@ local data = {
 		TypeParameter = "",
 		Unit = "",
 		Value = "",
-		Variable = "",
+		Variable = "",
 		-- ccls-specific icons.
 		TypeAlias = "",
 		Parameter = "",
@@ -108,6 +108,7 @@ local data = {
 		Perf = "",
 		Project = "",
 		Right = "",
+		RootFolderOpened = "",
 		Search = "",
 		Separator = "",
 		DoubleSeparator = "",

--- a/lua/modules/ui/plugins.lua
+++ b/lua/modules/ui/plugins.lua
@@ -9,13 +9,19 @@ ui["catppuccin/nvim"] = {
 	as = "catppuccin",
 	config = conf.catppuccin,
 }
+ui["zbirenbaum/neodim"] = {
+	opt = true,
+	event = "LspAttach",
+	requires = "nvim-treesitter/nvim-treesitter",
+	config = conf.neodim,
+}
 ui["rcarriga/nvim-notify"] = {
 	opt = false,
 	config = conf.notify,
 }
 ui["hoob3rt/lualine.nvim"] = {
 	opt = true,
-	after = "nvim-lspconfig",
+	after = { "nvim-lspconfig", "lspsaga.nvim" },
 	config = conf.lualine,
 }
 ui["goolord/alpha-nvim"] = {
@@ -23,7 +29,7 @@ ui["goolord/alpha-nvim"] = {
 	event = "BufWinEnter",
 	config = conf.alpha,
 }
-ui["kyazdani42/nvim-tree.lua"] = {
+ui["nvim-tree/nvim-tree.lua"] = {
 	opt = true,
 	cmd = {
 		"NvimTreeToggle",
@@ -33,6 +39,14 @@ ui["kyazdani42/nvim-tree.lua"] = {
 		"NvimTreeRefresh",
 	},
 	config = conf.nvim_tree,
+	requires = {
+		"s1n7ax/nvim-window-picker",
+		opt = true,
+		tag = "v1.*",
+		config = function()
+			require("window-picker").setup()
+		end,
+	},
 }
 ui["lewis6991/gitsigns.nvim"] = {
 	opt = true,
@@ -54,10 +68,6 @@ ui["dstein64/nvim-scrollview"] = {
 	opt = true,
 	event = { "BufReadPost" },
 	config = conf.scrollview,
-}
-ui["mbbill/undotree"] = {
-	opt = true,
-	cmd = "UndotreeToggle",
 }
 ui["j-hui/fidget.nvim"] = {
 	opt = true,

--- a/lua/modules/utils/init.lua
+++ b/lua/modules/utils/init.lua
@@ -1,0 +1,118 @@
+local M = {}
+
+---@param c string @The color in hexadecimal.
+local function hexToRgb(c)
+	c = string.lower(c)
+	return { tonumber(c:sub(2, 3), 16), tonumber(c:sub(4, 5), 16), tonumber(c:sub(6, 7), 16) }
+end
+
+---Parse the `style` string into nvim_set_hl options
+---@param style string @The style config
+---@return table
+local function parse_style(style)
+	if not style or style == "NONE" then
+		return {}
+	end
+
+	local result = {}
+	for field in string.gmatch(style, "([^,]+)") do
+		result[field] = true
+	end
+
+	return result
+end
+
+---Wrapper function for nvim_get_hl_by_name
+---@param hl_group string @Highlight group name
+---@return table
+local function get_highlight(hl_group)
+	local hl = vim.api.nvim_get_hl_by_name(hl_group, true)
+	if hl.link then
+		return get_highlight(hl.link)
+	end
+
+	local result = parse_style(hl.style)
+	result.fg = hl.foreground and string.format("#%06x", hl.foreground)
+	result.bg = hl.background and string.format("#%06x", hl.background)
+	result.sp = hl.special and string.format("#%06x", hl.special)
+	for attr, val in pairs(hl) do
+		if type(attr) == "string" and attr ~= "foreground" and attr ~= "background" and attr ~= "special" then
+			result[attr] = val
+		end
+	end
+
+	return result
+end
+
+--- Blend foreground with background
+---@param foreground string @The foreground color
+---@param background string @The background color to blend with
+---@param alpha number|string @Number between 0 and 1 for blending amount.
+function M.blend(foreground, background, alpha)
+	alpha = type(alpha) == "string" and (tonumber(alpha, 16) / 0xff) or alpha
+	local bg = hexToRgb(background)
+	local fg = hexToRgb(foreground)
+
+	local blendChannel = function(i)
+		local ret = (alpha * fg[i] + ((1 - alpha) * bg[i]))
+		return math.floor(math.min(math.max(0, ret), 255) + 0.5)
+	end
+
+	return string.format("#%02x%02x%02x", blendChannel(1), blendChannel(2), blendChannel(3))
+end
+
+--- Get RGB highlight by highlight group
+---@param hl_group string @Highlight group name
+---@param use_bg boolean @Returns background or not
+---@param fallback_hl? string @Fallback value if the hl group is not defined
+---@return string
+function M.hl_to_rgb(hl_group, use_bg, fallback_hl)
+	local hex = fallback_hl or "#000000"
+	local hlexists = M.tobool(tonumber(vim.api.nvim_exec('echo hlexists("' .. hl_group .. '")', true)))
+
+	if hlexists then
+		local result = get_highlight(hl_group)
+		if use_bg then
+			hex = result.bg and result.bg or "NONE"
+		else
+			hex = result.fg and result.fg or "NONE"
+		end
+	end
+
+	return hex
+end
+
+--- Extend a highlight group
+---@param name string @Target highlight group name
+---@param def table @Attributes to be extended
+function M.extend_hl(name, def)
+	local hlexists = M.tobool(tonumber(vim.api.nvim_exec('echo hlexists("' .. name .. '")', true)))
+	if not hlexists then
+		-- Do nothing if highlight group not found
+		return
+	end
+	local current_def = get_highlight(name)
+	local combined_def = vim.tbl_deep_extend("force", current_def, def)
+
+	vim.api.nvim_set_hl(0, name, combined_def)
+end
+
+--- Convert number (0/1) to boolean
+---@param value number? @The value to check, can be nil (API Error)
+---@return boolean|nil
+function M.tobool(value)
+	if value == 0 or value == nil then
+		return false
+	elseif value == 1 then
+		return true
+	else
+		vim.notify(
+			"Attempt to convert data of type '" .. type(value) .. "' [other than 0 or 1] to boolean",
+			vim.log.levels.ERROR,
+			{ title = "[utils] Runtime error" }
+		)
+		return nil
+	end
+end
+
+return M


### PR DESCRIPTION
- refactor(keymap): define `<A-q>` at keymap/init.lua.
- style(lualine): add extension for DiffviewFiles.
- chore(lspsags): replace deprecated signature_help with built-in signature_help
- chore(trouble): update new default/deprecated config
- feat(tools): support ripgrep agrs for telescope live_grep.
- feat(ui): show current work directory in lualine.
- chore(catppuccin): Update highlights
- fix: update code action keymap for legendary.
- feat: New plugin - zbirenbaum/neodim
- fix(plugins): remove error after PackerCompile.
- fix(ui): eliminate neodim's blend_color error for every colorscheme.
- feat: auto set root directory by using project.nvim.
- feat: make `format_on_save` configurable.
- chore(legendary): add frecency support
- chore(lspsaga): deprecate LSoutlineToggle, use Lspsaga outline instead
- pref: remove unused and redefined parameter `config`.
- fix: fix copilot issue when using dap
- chore(colorizer): prevent treesitter to overide background (#367)
- chore(lsp): disable lightbulb from lspsaga.
- fix: use native nvim api to close NvimTree, fix #368. (#369)
- feat(core): hot reload nvim core options
- perf: Fix wording for comments
- chore(neodim): Correctly set load sequence
- chore(notify): Update options
- chore(event): place hot reload event in `bufs` augroup
- chore(events): Prevent the user from being notified for hot reload
- chore(lua-lsp): prevent lua-ts highlightting being overwritten by lua-lsp (#373)
- chore: replace telescope-project.nvim with project.nvim. (#374)
- fix(lsp): use clang default capabilities with utf-16 as the first offsetEncoding option.
- perf: remove unnecessary placeholder, #375.
- fix(lsp-clangd): append default capabilities
- Revert "Merge pull request #371 from CharlesChiuGit/hot-reload-core"
- pref: Cleanup unnecessary code
- chore&fix(plugins): replace undotree with telescope-undo.
- perf: add more command for legendary.
- chore: use `NvimTreeToggle` because fixed at its pr #1833.
- chore(nvim-tree): update short url
- perf(ui): ui twick & update theme-related config (#383)
- feat: add `<leader>fb` keymap to find buffer.
- fix(keymap): use `<leader>r` to execute SnipRun for whole file, close #389.
- chore(keymap): use `<C-S-s>` in normal mode to force save for file need `sudo`.
- fix: auto close `NvimTree` follow its wiki.
- fix: use `s1n7ax/nvim-window-picker` to provide picker for `nvim-tree` (#392)
- fix(cmp): change loading order to avoid `cmp not found` when opening new file
- chore(cmp): better loading order
- fix(neodim): fix ts dependency for `neodim`
- fix: always show file name in winbar, close #398.
- Revert "fix(neodim): fix ts dependency for `neodim`"
- fix(enew): Ensure treesitter is in `rtp`
- chore&perf: replace bufdelete.nvim with nvim-bufdel.
- fix: remove redundant `:`.
- perf: Cleanup legacy code
- feat(lspsaga & lualine): Show symbols in lualine.
- fix(utils): Check if highlight exists properly
- chore(lualine): Update layout
- chore(catppuccin): Update highlights
- fix(catppuccin): Check for transparent background
- fix(utils): Check parameters' validity
- fix: Typo bg -> fg
- docs: add note comment for someone want to hack this config.
- pref(issue-template): Confirm latest commit
- fix(utils): Handle highlight linking properly
- chore(utils): Check attribute type to ignore cleared hl
- perf(copilot): update lazy loading for copilot
