### PR TITLE
ayamir main

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -97,7 +97,7 @@ local function load_options()
 		wildignorecase = true,
 		-- Do NOT adjust the following option (winblend) if you're using transparent background
 		winblend = 0,
-		winminwidth = 10,
+		winminwidth = 1,
 		winwidth = 30,
 		wrap = false,
 		wrapscan = true,


### PR DESCRIPTION
- pin(indent-blankline): stick to `2.20.8` for now
- chore(lockfile): auto update lazy-lock.json
- fix(ToggleTerm/keymap): respect `v:count` (#1012)
- chore(lockfile): auto update lazy-lock.json
- feat(ibl): support `indent-blankline` v3 (#1011)
- chore(lockfile): auto update lazy-lock.json
- fix(nixos): Add go lang. (#1016)
- chore(lockfile): auto update lazy-lock.json
- refactor(telescope-frecency)!: remove support for `sqlite.lua` (#1019)
- chore(lockfile): auto update lazy-lock.json
- chore(CI): bump deps versions (#1020)
- chore(lockfile): auto update lazy-lock.json
- fix(ibl): remove top level scope definition (`chunk`) (#1024)
- chore(lockfile): auto update lazy-lock.json
- fixup!: disable sqlite explicitly to eliminate warning. (#1027)
- chore(lockfile): auto update lazy-lock.json
- feat: support formatting changed lines only (#1028)
- chore(lockfile): auto update lazy-lock.json
- fix(keymap): use `<C-w>` with hjkl to navigate under `t` mode (#1029)
- chore(lockfile): auto update lazy-lock.json
- fix(pack): erroneous searcher for user configs (#1032)
- Adjust `winminwidth` from 10 to 1 to avoid conflict with `focus.nvim`
